### PR TITLE
Adding .travis.yml file for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+install:
+  - cd src/ted/
+  - sudo apt-get update
+  - sudo apt-get install qtcreator libqt5webkit5-dev qtlocation5-dev qtsensors5-dev libxslt-dev libsqlite3-dev libgstreamer-plugins-base0.10-dev
+script:
+  - qmake -project
+  - qmake ted.pro
+  - make
+os:
+  - linux
+  - osx


### PR DESCRIPTION
This will allow you to test building for Mac and Linux after every push request. It also allow you to test changes made by others, like me, and make sure they do not break anything without having to merge them. All you have to do is sign-in with your github at https://travis-ci.org and turn on the switch next to the repository name. (It is free for public repositories)

Example: https://travis-ci.org/Alshurafa/Jentos_IDE/builds/29648813
